### PR TITLE
chore(fix): error Named export 'Loader' not found (CommonJS)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,8 @@
 <script lang="ts">
   /* global google */
 
-  import { Loader } from '@googlemaps/js-api-loader';
+  import * as GMAPILoader from '@googlemaps/js-api-loader';
+  const { Loader } = GMAPILoader;
   import { onMount } from 'svelte';
 
   import SearchBar from './components/SearchBar.svelte';


### PR DESCRIPTION
Fix error

![image](https://github.com/googlemaps-samples/js-solar-potential/assets/41448663/f8928be8-1111-48e3-b2f3-ee03a91df011)
